### PR TITLE
Handle invalid queue jobs as failures

### DIFF
--- a/api/process-job.js
+++ b/api/process-job.js
@@ -26,9 +26,17 @@ export default async function handler(request, response) {
 
         if (!jobDoc.exists || jobDoc.data().status !== 'pending') {
             console.log(`[PROCESS-JOB ${jobId}] Job não encontrado, já processado ou inválido.`);
+            // Marca o job como falho caso o documento ainda exista, evitando pendências infinitas no front-end
+            if (jobDoc.exists) {
+                await jobRef.update({
+                    status: 'failed',
+                    finishedAt: Timestamp.now(),
+                    error: 'Job not found, already processed or invalid.'
+                }).catch(() => {});
+            }
             // Mesmo se o job não for válido, procuramos o próximo para não quebrar a corrente
             await triggerNextJob(userId, request.headers.host);
-            return response.status(200).send('Job already processed or invalid.');
+            return response.status(404).send('Job already processed or invalid.');
         }
 
         const jobData = jobDoc.data();


### PR DESCRIPTION
## Summary
- mark queue entries as `failed` when the worker receives an invalid or already processed job
- return HTTP 404 for invalid jobs so clients know the item was not processed

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b68c1011e083308831c70948eaaeac